### PR TITLE
fix(style): 修正文章中過高圖片覆蓋文字的問題

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -147,11 +147,12 @@
 /* Force responsive images within Yoopta editor content */
 .prose .yoopta-image img {
   width: 100% !important;
-  height: auto !important;
+  height: 100% !important;
   max-width: 100% !important;
   margin-left: auto;
   margin-right: auto;
   border-radius: 0.5rem;
+  object-fit: contain;
 }
 
 /* Fix for Yoopta image container width, height, min-width */
@@ -170,8 +171,9 @@
 @media (min-width: 768px) {
   .prose .yoopta-image img {
     width: auto !important;
-    height: auto !important;
+    height: 100% !important;
     max-width: 650px !important;
+    object-fit: contain;
   }
   .prose .yoo-image-flex {
     max-width: 650px !important;


### PR DESCRIPTION
變更文章內容的圖片樣式，將圖片高度限制為其容器的高度，並使用 object-fit: contain 來維持圖片的長寬比，避免圖片溢出其容器。

這解決了在文章中插入高度較高的圖片時，會覆蓋到下方文字的問題。