### PR TITLE
feat(blog): 新增文章頁面即時載入狀態

### DIFF
--- a/app/(public)/blog/[id]/loading.tsx
+++ b/app/(public)/blog/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { BlogDetailSkeleton } from '@/components/blog/BlogDetailSkeleton';
+
+export default function Loading() {
+  return <BlogDetailSkeleton />;
+}

--- a/app/(public)/blog/[id]/page.tsx
+++ b/app/(public)/blog/[id]/page.tsx
@@ -7,7 +7,7 @@ import { BlogDetailSkeleton } from '@/components/blog/BlogDetailSkeleton';
 import { SITE_CONFIG } from '@/lib/constants';
 
 type Props = {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 };
 
 // Server-side helper to quickly check for headings in Yoopta content
@@ -46,7 +46,7 @@ function extractTextFromContent(content: unknown): string {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { id } = await params;
+  const { id } = params;
   const post = await getPostById(id);
 
   if (!post) {
@@ -103,25 +103,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default async function BlogDetailPage({ params }: Props) {
-  const { id } = await params;
-  // Fetch post data here to determine `hasToc` for the skeleton.
-  // This call is deduplicated by Next.js and won't cause another database hit.
-  const post = await getPostById(id);
-
-  // If the post is not found, trigger the 404 page.
-  if (!post) {
-    notFound();
-  }
-
-  // Check for headings on the server to pass to the skeleton.
-  const hasToc = checkContentForHeadings(post.content);
+  const { id } = params;
 
   return (
     <article>
-      <Suspense fallback={<BlogDetailSkeleton hasToc={hasToc} />}>
-        {/* The BlogDetail component still fetches its own data, which hits the cache */}
-        <BlogDetail id={id} />
-      </Suspense>
+      {/* 
+        The `loading.tsx` file now acts as the Suspense boundary for this page.
+        The <BlogDetail> component fetches its own data, and Next.js will automatically 
+        show the loading.tsx UI during this data fetching process on navigation.
+      */}
+      <BlogDetail id={id} />
     </article>
   );
 }


### PR DESCRIPTION
為改善使用者體驗，解決從部落格列表導航至文章詳情頁時的延遲與白屏問題。

- **引入 `loading.tsx`**: 在文章詳情頁 (`/blog/[id]`) 加入 `loading.tsx` 檔案，利用 Next.js App Router 的慣例，在頁面切換時立即顯示骨架屏 (Skeleton) 作為載入反饋。

- **重構頁面元件**: 移除原頁面中手動控制的 `<Suspense>` 邊界，改由 `loading.tsx` 全權處理路由級別的載入狀態，使程式碼更簡潔且符合框架預期。

- **修正前置問題**: 補全原先遺失的 `getPostById` 資料擷取函式，並修正 `BlogDetailClient` 元件的建立與匯入問題，確保頁面能正確渲染。