### PR TITLE
fix(data): 修正文章日期顯示不一致的問題

### DIFF
--- a/app/api/posts/[id]/route.ts
+++ b/app/api/posts/[id]/route.ts
@@ -45,12 +45,9 @@ export async function GET(
         );
       }
 
-      const { tags, createdAt, updatedAt, ...rest } = post;
       const transformedPost = {
-        ...rest,
-        tags: tags.map((t) => t.tag),
-        created_at: createdAt?.toISOString?.() ?? '',
-        updated_at: updatedAt?.toISOString?.() ?? '',
+        ...post,
+        tags: post.tags.map((t) => t.tag),
       };
       
       return NextResponse.json({ success: true, data: transformedPost });

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -78,12 +78,10 @@ export async function GET(request: NextRequest) {
       prisma.post.count({ where }),
     ]);
 
-    // 轉換文章列表，將 tags 陣列中的 tag 物件轉換為 tag 名稱，並將日期轉為 ISO 字串
+    // 轉換文章列表，將 tags 陣列中的 tag 物件轉換為 tag 名稱
     const transformedPosts = posts.map(post => ({
       ...post,
       tags: post.tags.map(tag => tag.tag),
-      created_at: post.createdAt?.toISOString?.() ?? '',
-      updated_at: post.updatedAt?.toISOString?.() ?? '',
     }));
 
     return NextResponse.json({

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -31,9 +31,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // 確保 posts 是數組
     const posts = Array.isArray(result.data) ? result.data : [];
 
-    const blogUrls = posts.map((post: { slug: string; updated_at?: string; created_at: string }) => ({
+    const blogUrls = posts.map((post: { slug: string; updatedAt?: string; createdAt: string }) => ({
       url: `${baseUrl}/blog/${post.slug}`,
-      lastModified: new Date(post.updated_at || post.created_at),
+      lastModified: new Date(post.updatedAt || post.createdAt),
       changeFrequency: 'weekly' as const,
       priority: 0.6,
     }));

--- a/components/blog/BlogCard.tsx
+++ b/components/blog/BlogCard.tsx
@@ -44,7 +44,7 @@ export default function BlogCard({ post, priority = false, onCategoryClick, onSu
           </Link>
         </h2>
         <div className="text-xs text-gray-500">
-          {post.created_at ? new Date(post.created_at).toLocaleDateString('zh-TW') : ''}
+          {post.createdAt ? new Date(post.createdAt).toLocaleDateString('zh-TW') : ''}
         </div>
         <div className="flex flex-wrap gap-2">
           {post.category?.name && (

--- a/types/post-card.ts
+++ b/types/post-card.ts
@@ -6,9 +6,7 @@ export interface Post {
   title: string;
   coverImageUrl?: string;
   content?: YooptaContentValue;
-  created_at?: string;
   createdAt?: string;
-  updated_at?: string;
   updatedAt?: string;
   published?: boolean;
   category?: { id: number; name: string };


### PR DESCRIPTION
統一整個應用程式中與文章日期相關的資料結構，解決因駝峰式（createdAt）與蛇形（created_at）命名混用導致的前端顯示錯誤。

- 將文章卡片元件 (`BlogCard.tsx`) 中使用的日期欄位修正為 `createdAt`。
- 重構文章 API (`/api/posts` 及 `/[id]`)，使其回傳一致的 `post` 物件，不再建立多餘的 `created_at` 欄位。
- 更新網站地圖 (`sitemap.ts`) 以使用正確的日期欄位。
- 從 `Post` 型別定義中移除已棄用的 `created_at` 和 `updated_at` 欄位，提升程式碼清晰度。