### PR TITLE
ci: 改用 Vercel CLI 進行部署

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,17 +54,11 @@ jobs:
     needs: [build]
     if: github.ref == 'refs/heads/main'
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+    - name: Install Vercel CLI
+      run: npm install --global vercel@latest
     
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-    
-    - name: Install dependencies
-      run: npm ci --legacy-peer-deps
-    
-    - name: Trigger Vercel Deploy Hook
-      run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}" 
+    - name: Deploy to Vercel
+      run: vercel --prod --token ${{ secrets.VERCEL_TOKEN }}
+      env:
+        VERCEL_ORG_ID: ${{ secrets.VERCEL_USER_ID }}
+        VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
- 中斷 Vercel 與 GitHub 的自動部署整合。

- 在 GitHub Actions 工作流中，以 Vercel CLI 取代原有的 Deploy Hook。

- 部署流程現由 GitHub Actions 完全控制，僅在 main 分支成功建置後觸發。