### PR TITLE
fix(ci): 鎖定 Vercel CLI 版本以解決部署失敗問題

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
     - name: Install Vercel CLI
-      run: npm install --global vercel@latest
+      run: npm install --global vercel@46.0.3
     
     - name: Deploy to Vercel
       run: vercel --prod --token ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
- 將 GitHub Actions 工作流中 Vercel CLI 的安裝版本從 `latest` 鎖定為 `46.0.3`。

- 此舉旨在解決因 Vercel CLI `46.0.5` 版本可能引入的 `package-lock.json` 找不到問題。