### PR TITLE
fix(build): 修正 sitemap 產生時的建置錯誤

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,75 +1,52 @@
 import { MetadataRoute } from 'next';
 import { SITE_CONFIG } from '@/lib/constants';
+import { prisma } from '@/lib/prisma';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = SITE_CONFIG.url;
-  
+
+  const staticRoutes = [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'daily' as const,
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/blog`,
+      lastModified: new Date(),
+      changeFrequency: 'daily' as const,
+      priority: 0.8,
+    },
+  ];
+
   try {
-    // 獲取所有部落格文章
-    const res = await fetch(`${baseUrl}/api/posts`, {
-      next: { revalidate: 3600 } // 快取1小時
+    // 直接從資料庫獲取所有已發布的文章
+    const posts = await prisma.post.findMany({
+      where: {
+        published: true,
+      },
+      select: {
+        slug: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      orderBy: {
+        updatedAt: 'desc',
+      },
     });
-    
-    if (!res.ok) {
-      return [
-        {
-          url: baseUrl,
-          lastModified: new Date(),
-          changeFrequency: 'daily',
-          priority: 1,
-        },
-        {
-          url: `${baseUrl}/blog`,
-          lastModified: new Date(),
-          changeFrequency: 'daily',
-          priority: 0.8,
-        },
-      ];
-    }
 
-    const result = await res.json();
-    // 確保 posts 是數組
-    const posts = Array.isArray(result.data) ? result.data : [];
-
-    const blogUrls = posts.map((post: { slug: string; updatedAt?: string; createdAt: string }) => ({
+    const blogUrls = posts.map(post => ({
       url: `${baseUrl}/blog/${post.slug}`,
       lastModified: new Date(post.updatedAt || post.createdAt),
       changeFrequency: 'weekly' as const,
       priority: 0.6,
     }));
 
-    const sitemapUrls = [
-      {
-        url: baseUrl,
-        lastModified: new Date(),
-        changeFrequency: 'daily',
-        priority: 1,
-      },
-      {
-        url: `${baseUrl}/blog`,
-        lastModified: new Date(),
-        changeFrequency: 'daily',
-        priority: 0.8,
-      },
-      ...blogUrls,
-    ];
-
-    return sitemapUrls;
+    return [...staticRoutes, ...blogUrls];
   } catch (error) {
-    console.error('生成sitemap失敗:', error);
-    return [
-      {
-        url: baseUrl,
-        lastModified: new Date(),
-        changeFrequency: 'daily',
-        priority: 1,
-      },
-      {
-        url: `${baseUrl}/blog`,
-        lastModified: new Date(),
-        changeFrequency: 'daily',
-        priority: 0.8,
-      },
-    ];
+    console.error('生成 sitemap 失敗:', error);
+    // 即使獲取文章失敗，也回傳靜態路由
+    return staticRoutes;
   }
-} 
+}


### PR DESCRIPTION
sitemap.ts 在建置期間因試圖 fetch 未啟動的 API 路由而導致 CI/CD 環境中斷。

重構為直接使用 Prisma 查詢資料庫，移除對執行中伺服器的依賴，確保建置過程的穩定性。