### PR TITLE
fix(typography): 修正前台文章內容字體顏色未顯示的問題

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,6 +42,20 @@ module.exports = {
         lg: 'var(--radius-lg)',
         xl: 'var(--radius-xl)',
       },
+      typography: ({ theme }) => ({
+        DEFAULT: {
+          css: {
+            '--tw-prose-body': 'inherit',
+            '--tw-prose-headings': 'inherit',
+            '--tw-prose-lead': 'inherit',
+            '--tw-prose-bold': 'inherit',
+            '--tw-prose-quotes': 'inherit',
+            '--tw-prose-code': 'inherit',
+            '--tw-prose-captions': 'inherit',
+            '--tw-prose-links': theme('colors.blue.600'),
+          },
+        },
+      }),
     },
   },
   plugins: [


### PR DESCRIPTION
調整 Tailwind CSS typography 外掛設定，避免其預設樣式覆蓋 Yoopta 編輯器產生的行內顏色。